### PR TITLE
refactor: 매칭을 찾는 메소드와 매칭 결과를 처리하는 메소드의 역할 구분

### DIFF
--- a/src/main/java/com/dnlab/tacktogetherbackend/match/controller/MatchController.java
+++ b/src/main/java/com/dnlab/tacktogetherbackend/match/controller/MatchController.java
@@ -51,7 +51,7 @@ public class MatchController {
             log.info("Match Succeed!");
 
             // 매칭 결과 생성
-            Map<String, MatchResultInfoDTO> resultInfoDTOMap = matchService.getMatchResultInfos(matchRequestId, opponentMatchRequestId);
+            Map<String, MatchResultInfoDTO> resultInfoDTOMap = matchService.handlePendingMatchedAndGetMatchResultInfos(matchRequestId, opponentMatchRequestId);
 
             // 매칭 결과를 각각 전송
             messagingTemplate.convertAndSendToUser(resultInfoDTOMap.get(opponentMatchRequestId).getUsername(), DESTINATION_URL, resultInfoDTOMap.get(opponentMatchRequestId));

--- a/src/main/java/com/dnlab/tacktogetherbackend/match/service/MatchService.java
+++ b/src/main/java/com/dnlab/tacktogetherbackend/match/service/MatchService.java
@@ -13,7 +13,7 @@ public interface MatchService {
     Optional<MatchRequest> getMatchRequestById(String matchRequestId);
     void removeRideRequest(String matchRequestId);
     String findMatchingMatchRequests(String matchRequestId);
-    Map<String, MatchResultInfoDTO> getMatchResultInfos(String matchRequestId, String matchedMatchRequestsId);
+    Map<String, MatchResultInfoDTO> handlePendingMatchedAndGetMatchResultInfos(String matchRequestId, String matchedMatchRequestsId);
     MatchDecisionStatus acceptMatch(String matchRequestId);
     void rejectMatch(String matchRequestId);
     void resetMatchRequests();


### PR DESCRIPTION
기존에는 매칭 찾는 메소드에서 매칭 결과를 처리하는 로직도 조금 포함되어있었으나 명확히 구분

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
 
- [ ] 기능 삭제

- [X] 버그 수정

- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
jeongmu1/develop -> kimmin1kk/main

### 변경 사항 
- 거절로직 변경
- 적합한 매칭 찾는 메소드, 찾은 후 처리 메소드 역할 명확히 분리
- 기존에는 MatchRequest의 matched필드 사용하지 않았지만 사용하도록 변경